### PR TITLE
fix: correct AuthService gRPC method mapping

### DIFF
--- a/apps/auth-service/src/controllers/user.controller.spec.ts
+++ b/apps/auth-service/src/controllers/user.controller.spec.ts
@@ -1,0 +1,23 @@
+import 'reflect-metadata';
+import { PATTERN_METADATA } from '@nestjs/microservices/constants';
+import { UserController } from './user.controller';
+
+describe('UserController gRPC mapping', () => {
+  const cases: Array<[keyof UserController, string]> = [
+    ['register', 'Register'],
+    ['login', 'Login'],
+    ['validateToken', 'ValidateToken'],
+    ['refreshToken', 'RefreshToken'],
+  ];
+
+  it.each(cases)('should map %s to RPC %s', (methodName, rpc) => {
+    const target = UserController.prototype as Record<string, unknown>;
+    const method = target[methodName] as () => unknown;
+    const metadata = Reflect.getMetadata(PATTERN_METADATA, method) as Array<{
+      service: string;
+      rpc: string;
+    }>;
+    expect(metadata).toBeDefined();
+    expect(metadata[0]).toMatchObject({ service: 'AuthService', rpc });
+  });
+});

--- a/apps/auth-service/src/controllers/user.controller.ts
+++ b/apps/auth-service/src/controllers/user.controller.ts
@@ -1,7 +1,6 @@
 import { Controller } from '@nestjs/common';
-import { UserService } from '../services/user.service';
-import { AuthServiceControllerMethods } from '@app/common';
 import { GrpcMethod } from '@nestjs/microservices';
+import { UserService } from '../services/user.service';
 import type {
   RegisterRequest,
   RegisterResponse,
@@ -17,24 +16,24 @@ import type {
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
-  @GrpcMethod('AuthService', 'register')
+  @GrpcMethod('AuthService', 'Register')
   async register(request: RegisterRequest): Promise<RegisterResponse> {
     return this.userService.register(request);
   }
 
-  @GrpcMethod('AuthService', 'login')
+  @GrpcMethod('AuthService', 'Login')
   async login(request: LoginRequest): Promise<LoginResponse> {
     return this.userService.login(request);
   }
 
-  @GrpcMethod('AuthService', 'validateToken')
+  @GrpcMethod('AuthService', 'ValidateToken')
   async validateToken(
     request: ValidateTokenRequest,
   ): Promise<ValidateTokenResponse> {
     return this.userService.validateToken(request);
   }
 
-  @GrpcMethod('AuthService', 'refreshToken')
+  @GrpcMethod('AuthService', 'RefreshToken')
   async refreshToken(
     request: RefreshTokenRequest,
   ): Promise<RefreshTokenResponse> {


### PR DESCRIPTION
## Summary
- ensure AuthService UserController uses proto's capitalized RPC names
- add unit test verifying gRPC method mapping metadata

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Unsafe return of a value of type `any` and other existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af2817ce54832aa4c094fccbc9f578