### PR TITLE
Fix LoginResponse errors field number

### DIFF
--- a/proto/auth.proto
+++ b/proto/auth.proto
@@ -46,7 +46,7 @@ message LoginResponse {
   string refreshToken = 2;
   string message = 3;
   bool success = 4;
-  repeated string errors = 6;
+  repeated string errors = 5;
 }
 
 // Token validation


### PR DESCRIPTION
## Summary
- Correct the field numbering in `LoginResponse` by changing the `errors` field from `6` to `5`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68af29d2d324832abe8d3896799805c3